### PR TITLE
Add Left turn maze solving

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -162,7 +162,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "mazegenerator"
-version = "0.4.1"
+version = "0.5.0"
 dependencies = [
  "image 0.18.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mazegenerator"
-version = "0.4.1"
+version = "0.5.0"
 authors = ["TheRiven <Novajames276@gmail.com>"]
 
 [dependencies]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -28,7 +28,7 @@ pub fn create_and_save_maze(maze_height: u32, maze_width: u32) -> HashSet<(u32, 
     // Setup Timer
     let timer = Instant::now();
 
-    let generator = select_maze_solver(height, width);
+    let generator = select_maze_generator(height, width);
     let maze = mazebuilder::generate_maze(generator);
     println!("Maze Generated in {:?}", timer.elapsed());
 
@@ -53,7 +53,7 @@ pub fn solve_maze(height: u32, width: u32, maze: &HashSet<(u32, u32)>) {
     );
 
     let timer = Instant::now();
-    let path = mazesolver::solve_maze(mazesolver::Solver::BFS, &start_point, end_point, maze);
+    let path = mazesolver::solve_maze(select_maze_solver(), &start_point, end_point, maze);
 
     if path == None {
         println!("Something went wrong and no path was found!");
@@ -78,7 +78,7 @@ fn save_solved_maze(height: u32, width: u32, maze: &HashSet<(u32, u32)>, path: V
     println!("Image saved in {:?}", timer.elapsed());
 }
 
-fn select_maze_solver(height: u32, width: u32) -> mazebuilder::Generator {
+fn select_maze_generator(height: u32, width: u32) -> mazebuilder::Generator {
     use std::io;
     let mut input = String::new();
 
@@ -87,7 +87,7 @@ fn select_maze_solver(height: u32, width: u32) -> mazebuilder::Generator {
     println!("2. Kruskal,");
     io::stdin()
         .read_line(&mut input)
-        .expect("select_maze_solver -- unable to parse console input!");
+        .expect("select_maze_generator -- unable to parse console input!");
 
     let option = match input.trim().parse::<u32>() {
         Ok(num) => num,
@@ -105,5 +105,33 @@ fn select_maze_solver(height: u32, width: u32) -> mazebuilder::Generator {
             mazebuilder::Generator::DFS {height, width}
         }
     }
+}
 
+fn select_maze_solver() -> mazesolver::Solver {
+    use std::io;
+    let mut input = String::new();
+
+    println!("Which maze solver do you want to use?");
+    println!("1. Breadth First Search,");
+    println!("2. Left-turn,");
+    io::stdin()
+        .read_line(&mut input)
+        .expect("select_maze_solver -- unable to parse console input!");
+
+    let option = match input.trim().parse::<u32>() {
+        Ok(num) => num,
+        Err(err) => {
+            println!("Please enter a number! Error: {}", err);
+            std::process::exit(1);
+        }
+    };
+
+    match option {
+        1 => mazesolver::Solver::BFS,
+        2 => mazesolver::Solver::LeftTurn,
+        _ => {
+            println!("unrecognised option {}, defaulting to BFS", option);
+            mazesolver::Solver::BFS
+        }
+    }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -52,8 +52,9 @@ pub fn solve_maze(height: u32, width: u32, maze: &HashSet<(u32, u32)>) {
         start_point, end_point
     );
 
+    let solver = select_maze_solver();
     let timer = Instant::now();
-    let path = mazesolver::solve_maze(select_maze_solver(), &start_point, end_point, maze);
+    let path = mazesolver::solve_maze(solver, &start_point, end_point, maze);
 
     if path == None {
         println!("Something went wrong and no path was found!");

--- a/src/mazesolver/leftturn.rs
+++ b/src/mazesolver/leftturn.rs
@@ -1,0 +1,152 @@
+use std::collections::HashSet;
+
+// location tracking object
+struct Person {
+    x: u32,
+    y: u32,
+    facing: Direction,
+}
+
+#[derive(Clone, Copy)]
+enum Direction {
+    North,
+    East,
+    South,
+    West,
+}
+
+// Entry function
+pub fn left_first<'a>(
+    start: &'a (u32, u32),
+    end: (u32, u32),
+    maze: &'a HashSet<(u32, u32)>,
+) -> Option<Vec<&'a (u32, u32)>> {
+    // Create a person at the start of the maze
+    let mut person = Person {
+        x: start.0,
+        y: start.1,
+        facing: Direction::South,
+    };
+
+    let at_end = true;
+    let mut path: Vec<&'a (u32, u32)> = Vec::new();
+
+    // While the person is not at the end of the maze
+    while at_end {
+        // Add the current node to the path.
+        path.push(
+            maze.get(&(person.x, person.y))
+                .expect("Tried to get maze position using player, but no cell found!"),
+        );
+
+        // Check if we are at the end of the maze
+        if (person.x, person.y) == end {
+            return Some(path);
+        }
+
+        // Find the next position to move to.
+        let (next_step, new_facing) = find_next_step(&maze, &person);
+
+        // Move the person to that position
+        person = move_person(person, next_step, new_facing);
+    }
+
+    None
+}
+
+fn get_direction(
+    maze: &HashSet<(u32, u32)>,
+    person: &Person,
+    direction: Direction,
+) -> Option<(u32, u32)> {
+    match direction {
+        Direction::North => (get_node(maze, person.x, person.y - 1)),
+        Direction::East => (get_node(maze, person.x + 1, person.y)),
+        Direction::South => (get_node(maze, person.x, person.y + 1)),
+        Direction::West => (get_node(maze, person.x - 1, person.y)),
+    }
+}
+
+fn get_node(maze: &HashSet<(u32, u32)>, x: u32, y: u32) -> Option<(u32, u32)> {
+    let node = maze.get(&(x, y));
+
+    match node {
+        Some(value) => Some(*value),
+        None => None,
+    }
+}
+
+fn move_person(_person: Person, position: (u32, u32), new_facing: Direction) -> Person {
+    Person {
+        x: position.0,
+        y: position.1,
+        facing: new_facing,
+    }
+}
+
+fn look_left(maze: &HashSet<(u32, u32)>, person: &Person) -> (Option<(u32, u32)>, Direction) {
+    match person.facing {
+        Direction::North => (get_direction(&maze, &person, Direction::West), Direction::West),
+        Direction::East => (get_direction(&maze, &person, Direction::North), Direction::North),
+        Direction::South => (get_direction(&maze, &person, Direction::East), Direction::East),
+        Direction::West => (get_direction(&maze, &person, Direction::South), Direction::South),
+    }
+}
+
+fn look_right(maze: &HashSet<(u32, u32)>, person: &Person) -> (Option<(u32, u32)>, Direction) {
+    match person.facing {
+        Direction::North => (get_direction(&maze, &person, Direction::East), Direction::East),
+        Direction::East => (get_direction(&maze, &person, Direction::South), Direction::South),
+        Direction::South => (get_direction(&maze, &person, Direction::West), Direction::West),
+        Direction::West => (get_direction(&maze, &person, Direction::North), Direction::North),
+    }
+}
+
+fn look_back(maze: &HashSet<(u32, u32)>, person: &Person) -> Option<((u32, u32), Direction)> {
+    match person.facing {
+        Direction::North => {
+            match get_direction(&maze, &person, Direction::South) {
+                Some(position) => Some((position, Direction::South)),
+                None => None,
+            }            
+        },
+        Direction::East => {
+            match get_direction(&maze, &person, Direction::West) {
+                Some(position) => Some((position, Direction::West)),
+                None => None,
+            }
+        },
+        Direction::South => {
+            match get_direction(&maze, &person, Direction::North) {
+                Some(position) => Some((position, Direction::North)),
+                None => None,
+            }
+        },
+        Direction::West => {
+            match get_direction(&maze, &person, Direction::East) {
+                Some(position) => Some((position, Direction::East)),
+                None => None,
+            }
+        },
+    }
+}
+
+fn find_next_step(maze: &HashSet<(u32, u32)>, person: &Person) -> ((u32, u32), Direction) {
+    // Look left, if there is a path then that is the way to move,
+    // if not look foward and move if there is a path.
+    // if there is nothing left or foward, try right.
+    // finaly if there is nothing else, go back.
+    if let (Some(left), dir) = look_left(&maze, &person) {
+        return (left, dir);
+    };
+
+    if let Some(forward) = get_direction(&maze, &person, person.facing) {
+        return (forward, person.facing);
+    };
+
+    if let (Some(right), dir) = look_right(&maze, &person) {
+        return (right, dir);
+    };
+
+    look_back(&maze, &person).expect("find_next_step -- No Path back from current location found!")
+}

--- a/src/mazesolver/leftturn.rs
+++ b/src/mazesolver/leftturn.rs
@@ -84,50 +84,41 @@ fn move_person(_person: Person, position: (u32, u32), new_facing: Direction) -> 
     }
 }
 
-fn look_left(maze: &HashSet<(u32, u32)>, person: &Person) -> (Option<(u32, u32)>, Direction) {
+fn look_left(maze: &HashSet<(u32, u32)>, person: &Person) -> Option<((u32, u32), Direction)> {
     match person.facing {
-        Direction::North => (get_direction(&maze, &person, Direction::West), Direction::West),
-        Direction::East => (get_direction(&maze, &person, Direction::North), Direction::North),
-        Direction::South => (get_direction(&maze, &person, Direction::East), Direction::East),
-        Direction::West => (get_direction(&maze, &person, Direction::South), Direction::South),
+        Direction::North => get_cell_from_direction(maze, person, Direction::West),
+        Direction::East => get_cell_from_direction(maze, person, Direction::North),
+        Direction::South => get_cell_from_direction(maze, person, Direction::East),
+        Direction::West => get_cell_from_direction(maze, person, Direction::South),
     }
 }
 
-fn look_right(maze: &HashSet<(u32, u32)>, person: &Person) -> (Option<(u32, u32)>, Direction) {
+fn look_right(maze: &HashSet<(u32, u32)>, person: &Person) -> Option<((u32, u32), Direction)> {
     match person.facing {
-        Direction::North => (get_direction(&maze, &person, Direction::East), Direction::East),
-        Direction::East => (get_direction(&maze, &person, Direction::South), Direction::South),
-        Direction::South => (get_direction(&maze, &person, Direction::West), Direction::West),
-        Direction::West => (get_direction(&maze, &person, Direction::North), Direction::North),
+        Direction::North => get_cell_from_direction(maze, person, Direction::East),
+        Direction::East => get_cell_from_direction(maze, person, Direction::South),
+        Direction::South => get_cell_from_direction(maze, person, Direction::West),
+        Direction::West => get_cell_from_direction(maze, person, Direction::North),
     }
 }
 
 fn look_back(maze: &HashSet<(u32, u32)>, person: &Person) -> Option<((u32, u32), Direction)> {
     match person.facing {
-        Direction::North => {
-            match get_direction(&maze, &person, Direction::South) {
-                Some(position) => Some((position, Direction::South)),
-                None => None,
-            }            
-        },
-        Direction::East => {
-            match get_direction(&maze, &person, Direction::West) {
-                Some(position) => Some((position, Direction::West)),
-                None => None,
-            }
-        },
-        Direction::South => {
-            match get_direction(&maze, &person, Direction::North) {
-                Some(position) => Some((position, Direction::North)),
-                None => None,
-            }
-        },
-        Direction::West => {
-            match get_direction(&maze, &person, Direction::East) {
-                Some(position) => Some((position, Direction::East)),
-                None => None,
-            }
-        },
+        Direction::North => get_cell_from_direction(maze, person, Direction::South),
+        Direction::East => get_cell_from_direction(maze, person, Direction::West),
+        Direction::South => get_cell_from_direction(maze, person, Direction::North),
+        Direction::West => get_cell_from_direction(maze, person, Direction::East),
+    }
+}
+
+fn get_cell_from_direction(
+    maze: &HashSet<(u32, u32)>,
+    person: &Person,
+    dir: Direction,
+) -> Option<((u32, u32), Direction)> {
+    match get_direction(&maze, &person, dir) {
+        Some(position) => Some((position, dir)),
+        None => None,
     }
 }
 
@@ -136,17 +127,17 @@ fn find_next_step(maze: &HashSet<(u32, u32)>, person: &Person) -> ((u32, u32), D
     // if not look foward and move if there is a path.
     // if there is nothing left or foward, try right.
     // finaly if there is nothing else, go back.
-    if let (Some(left), dir) = look_left(&maze, &person) {
-        return (left, dir);
+    if let Some(left) = look_left(maze, person) {
+        return left;
     };
 
-    if let Some(forward) = get_direction(&maze, &person, person.facing) {
+    if let Some(forward) = get_direction(maze, person, person.facing) {
         return (forward, person.facing);
     };
 
-    if let (Some(right), dir) = look_right(&maze, &person) {
-        return (right, dir);
+    if let Some(right) = look_right(maze, person) {
+        return right;
     };
 
-    look_back(&maze, &person).expect("find_next_step -- No Path back from current location found!")
+    look_back(maze, person).expect("find_next_step -- No Path back from current location found!")
 }

--- a/src/mazesolver/mod.rs
+++ b/src/mazesolver/mod.rs
@@ -1,9 +1,11 @@
 mod bfs;
+mod leftturn;
 
 use std::collections::HashSet;
 
 pub enum Solver {
     BFS,
+    LeftTurn,
 }
 
 pub fn solve_maze<'a>(
@@ -14,6 +16,7 @@ pub fn solve_maze<'a>(
 ) -> Option<Vec<&'a (u32, u32)>> {
     let path = match solver {
         Solver::BFS => bfs::breadth_first_search(start, end, maze),
+        Solver::LeftTurn => leftturn::left_first(start, end, maze),
     };
 
     path


### PR DESCRIPTION
Adds a new maze solving algorithm and allows users to select which solver they want to use.

Left turn will prioritise keeping a wall left of a "person" as they move through to the end.